### PR TITLE
Add fix for unclosed HTML breaks

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/Utils/Utils.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Utils/Utils.cs
@@ -47,7 +47,8 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Utilities
 
             if (description.Length > maxLength)
             {
-                description = description.Replace("\n", "<br>", System.StringComparison.CurrentCulture).Substring(0, maxLength);
+                description = description.Substring(0, maxLength);
+                description = description.Replace("\n", "<br>", System.StringComparison.CurrentCulture);
             }
 
             return description;


### PR DESCRIPTION
This changes the order of operations, truncating description before replacing newlines with HTML breaks, to prevent the creation of unclosed breaks which may otherwise cause rendering issues in Jellyfin.

Edit: I extend my apologies if it is considered poor etiquette to submit this pull request before you've had a chance to reply to the relevant issue.  I've been taking this as an opportunity to better familiarize myself with git and GitHub, both of which I'm fairly naive to.