### PR TITLE
feat: Add backdrop image to series

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/Providers/SeriesImageProvider.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Providers/SeriesImageProvider.cs
@@ -85,6 +85,12 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Providers
                     Type = ImageType.Banner,
                     Url = channel.BannerUrl
                 });
+                list.Add(new RemoteImageInfo
+                {
+                    ProviderName = Name,
+                    Type = ImageType.Backdrop,
+                    Url = channel.TvartUrl
+                });
             }
 
             return list;


### PR DESCRIPTION
This PR adds the TVArt as the Backdrop image for series in JellyFin.

This closes #17 