### PR TITLE
Fix ArgumentNullException when channel has no tags

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Channel/Channel.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Channel/Channel.cs
@@ -126,7 +126,9 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
                         Type = ImageType.Primary
                     }
                 },
-                Tags = this.Tags != null ? this.Tags.ToArray<string>() : []
+                Tags = this.Tags != null ?
+                    this.Tags.ToArray<string>() :
+                    []
             };
         }
     }

--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Channel/Channel.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Channel/Channel.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
                         Type = ImageType.Primary
                     }
                 },
-                Tags = this.Tags.ToArray<string>()
+                Tags = this.Tags != null ? this.Tags.ToArray<string>() : []
             };
         }
     }


### PR DESCRIPTION
Fixes https://github.com/tubearchivist/tubearchivist-jf-plugin/issues/12.

As seen in the log lines below, some channels return a channel_tags of null:
```
{"channel_banner_url":"/cache/channels/UCuCkxoKLYO_EQ2GeFtbM_bw_banner.jpg","channel_description":"Education-y explainer videos that are almost good enough to watch.","channel_id":"UCuCkxoKLYO_EQ2GeFtbM_bw","channel_name":"Half as Interesting","channel_tags":null,"channel_thumb_url":"/cache/channels/UCuCkxoKLYO_EQ2GeFtbM_bw_thumb.jpg","channel_tvart_url":"/cache/channels/UCuCkxoKLYO_EQ2GeFtbM_bw_tvart.jpg"}
```

It looks like this was intended to be accounted for with the `TagsJsonConverter`, but my hunch is that it's not being invoked by the JSON deserializer because the value is null, so there's no object to convert.

This change adds a simple null check and, based on my local testing, successfully allows tubearchivist-jf-plugin to fetch channel metadata for channels with no tags.