### PR TITLE
Added new method for auth headers

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Configuration/PluginConfiguration.cs
@@ -125,7 +125,19 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Configuration
 
             set
             {
-                value.Replace(" ", string.Empty, StringComparison.CurrentCulture).Split(',').ToList().ForEach(u => _jfUsernamesTo.Add(u));
+                // Clear existing usernames
+                _jfUsernamesTo.Clear();
+                
+                // Split by comma, then trim each part to remove leading/trailing spaces
+                foreach (var username in value.Split(','))
+                {
+                    var trimmedUsername = username.Trim();
+                    if (!string.IsNullOrEmpty(trimmedUsername))
+                    {
+                        _jfUsernamesTo.Add(trimmedUsername);
+                    }
+                }
+                
                 _logger.LogDebug("Set JFUsernamesTo to: {Message}", value);
             }
         }

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Configuration/PluginConfiguration.cs
@@ -87,7 +87,8 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Configuration
             set
             {
                 _tubeArchivistApiKey = value;
-                Plugin.Instance?.LogTAApiConnectionStatus();
+                Plugin.Instance?.LogTAApiConnectionStatus();            
+                Plugin.Instance?.UpdateAuthorizationHeader();
             }
         }
 

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Configuration/PluginConfiguration.cs
@@ -87,8 +87,8 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Configuration
             set
             {
                 _tubeArchivistApiKey = value;
-                Plugin.Instance?.LogTAApiConnectionStatus();            
-                Plugin.Instance?.UpdateAuthorizationHeader();
+                Plugin.Instance?.LogTAApiConnectionStatus();
+                Plugin.Instance?.UpdateAuthorizationHeader(value);
             }
         }
 
@@ -127,7 +127,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Configuration
             {
                 // Clear existing usernames
                 _jfUsernamesTo.Clear();
-                
+
                 // Split by comma, then trim each part to remove leading/trailing spaces
                 foreach (var username in value.Split(','))
                 {
@@ -137,8 +137,8 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Configuration
                         _jfUsernamesTo.Add(trimmedUsername);
                     }
                 }
-                
-                _logger.LogDebug("Set JFUsernamesTo to: {Message}", value);
+
+                _logger.LogDebug("Set JFUsernamesTo to: {Message}", string.Join(", ", _jfUsernamesTo));
             }
         }
 

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -57,9 +57,8 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
             handler.AllowAutoRedirect = false;
             handler.CheckCertificateRevocationList = true;
             HttpClient = new HttpClient(handler);
-            
-            UpdateAuthorizationHeader();
-            
+            UpdateAuthorizationHeader(Configuration.TubeArchivistApiKey);
+
             SessionManager = sessionManager;
             sessionManager.PlaybackProgress += OnPlaybackProgress;
             LibraryManager = libraryManager;
@@ -133,12 +132,12 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
         /// <summary>
         /// Updates the HTTP client's Authorization header with the current API key.
         /// </summary>
-        public void UpdateAuthorizationHeader()
+        /// <param name="apiKey">TubeArchivist API key.</param>
+        public void UpdateAuthorizationHeader(string apiKey)
         {
-            if (!string.IsNullOrEmpty(Configuration.TubeArchivistApiKey))
+            if (!string.IsNullOrEmpty(apiKey))
             {
-                HttpClient.DefaultRequestHeaders.Authorization = 
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Configuration.TubeArchivistApiKey);
+                HttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", apiKey);
                 Logger.LogInformation("{Message}", "Updated Authorization header with API key");
             }
             else

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -57,7 +57,9 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
             handler.AllowAutoRedirect = false;
             handler.CheckCertificateRevocationList = true;
             HttpClient = new HttpClient(handler);
-            HttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Instance?.Configuration.TubeArchivistApiKey);
+            
+            UpdateAuthorizationHeader();
+            
             SessionManager = sessionManager;
             sessionManager.PlaybackProgress += OnPlaybackProgress;
             LibraryManager = libraryManager;
@@ -127,6 +129,23 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
                 EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.configPage.html", GetType().Namespace)
             }
         };
+
+        /// <summary>
+        /// Updates the HTTP client's Authorization header with the current API key.
+        /// </summary>
+        public void UpdateAuthorizationHeader()
+        {
+            if (!string.IsNullOrEmpty(Configuration.TubeArchivistApiKey))
+            {
+                HttpClient.DefaultRequestHeaders.Authorization = 
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Configuration.TubeArchivistApiKey);
+                Logger.LogInformation("{Message}", "Updated Authorization header with API key");
+            }
+            else
+            {
+                Logger.LogWarning("{Message}", "No TubeArchivist API key configured");
+            }
+        }
 
         /// <summary>
         /// Logs the TubeArchivist API connection status.


### PR DESCRIPTION
PR for the below referenced issue 

https://github.com/tubearchivist/tubearchivist-jf-plugin/issues/37

I'm not sure what tests are being done to validate any issues introduced by proposed changes -- are there any scripts needed to be ran after build?

Changes introduced:
- Create a new method called UpdateAuthorizationHeader
    - This checks if Configuration.TubeArchivistApiKey is not null. If this is not null, use the provided token as an api key for the authorization header and log a message indicating the header was created
    - If this is null, log a message indicating that there is no api key configured
- Replace the previous auth header setter with the new method
- Add method call to plugin configuration file for the api key