### PR TITLE
Fix serialisation of videos from TA API

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/TubeArchivistApi.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/TubeArchivistApi.cs
@@ -95,7 +95,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
         /// <returns>A task.</returns>
         public async Task<Video?> GetVideo(string videoId)
         {
-            ResponseContainer<Video>? video = null;
+            Video? video = null;
 
             var videosEndpoint = "/api/video/";
             var url = new Uri(Utils.SanitizeUrl(Plugin.Instance?.Configuration.TubeArchivistUrl + videosEndpoint + videoId));
@@ -112,10 +112,10 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
             if (response.IsSuccessStatusCode)
             {
                 string rawData = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-                video = JsonConvert.DeserializeObject<ResponseContainer<Video>>(rawData);
+                video = JsonConvert.DeserializeObject<Video>(rawData);
             }
 
-            return video?.Data;
+            return video;
         }
 
         /// <summary>


### PR DESCRIPTION
I think the TA API has changed upstream because my metadata suddenly stopped pulling through and this was the fix that I did locally to get things working again.

I checked `/api/docs/#/video/video_retrieve_2` on my instance and see that it is not wrapped in a `data` tag in the docs either.