### PR TITLE
Episodes by YYYYMMDD and some other cleanup

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -179,19 +179,19 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
 
                 if ((topParent?.Name ?? string.Empty) == (Instance?.Configuration.CollectionTitle ?? string.Empty) && topParent?.Name is not null)
                 {
-                BaseItem? season = LibraryManager.GetItemById(eventArgs.Item.ParentId);
-                BaseItem? channel = LibraryManager.GetItemById(season!.ParentId);
-                BaseItem? collection = LibraryManager.GetItemById(channel!.ParentId);
-                if (collection?.Name.ToLower(CultureInfo.CurrentCulture) == Instance?.Configuration.CollectionTitle.ToLower(CultureInfo.CurrentCulture) && eventArgs.PlaybackPositionTicks != null)
-                {
-                    long progress = (long)eventArgs.PlaybackPositionTicks / TimeSpan.TicksPerSecond;
-                    var videoId = Utils.GetVideoNameFromPath(eventArgs.Item.Path);
-                    var statusCode = await TubeArchivistApi.GetInstance().SetProgress(videoId, progress).ConfigureAwait(true);
-                    if (statusCode != System.Net.HttpStatusCode.OK)
+                    BaseItem? season = LibraryManager.GetItemById(eventArgs.Item.ParentId);
+                    BaseItem? channel = LibraryManager.GetItemById(season!.ParentId);
+                    BaseItem? collection = LibraryManager.GetItemById(channel!.ParentId);
+                    if (collection?.Name.ToLower(CultureInfo.CurrentCulture) == Instance?.Configuration.CollectionTitle.ToLower(CultureInfo.CurrentCulture) && eventArgs.PlaybackPositionTicks != null)
                     {
-                        Logger.LogCritical("{Message}", $"POST /video/{videoId}/progress returned {statusCode} for video {eventArgs.Item.Name} with progress {progress} seconds");
+                        long progress = (long)eventArgs.PlaybackPositionTicks / TimeSpan.TicksPerSecond;
+                        var videoId = Utils.GetVideoNameFromPath(eventArgs.Item.Path);
+                        var statusCode = await TubeArchivistApi.GetInstance().SetProgress(videoId, progress).ConfigureAwait(true);
+                        if (statusCode != System.Net.HttpStatusCode.OK)
+                        {
+                            Logger.LogCritical("{Message}", $"POST /video/{videoId}/progress returned {statusCode} for video {eventArgs.Item.Name} with progress {progress} seconds");
+                        }
                     }
-                }
                 }
                 else
                 {
@@ -209,53 +209,53 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
 
                 if ((topParent?.Name ?? string.Empty) == (Instance?.Configuration.CollectionTitle ?? string.Empty) && topParent?.Name is not null)
                 {
-                var isPlayed = eventArgs.Item.IsPlayed(user);
-                Logger.LogDebug("User {UserId} changed watched status to {Status} for the item {ItemName}", eventArgs.UserId, isPlayed, eventArgs.Item.Name);
-                string itemYTId;
-                try
-                {
-                    if (eventArgs.Item is Series)
+                    var isPlayed = eventArgs.Item.IsPlayed(user);
+                    Logger.LogDebug("User {UserId} changed watched status to {Status} for the item {ItemName}", eventArgs.UserId, isPlayed, eventArgs.Item.Name);
+                    string itemYTId;
+                    try
                     {
-                        itemYTId = Utils.GetChannelNameFromPath(eventArgs.Item.Path);
-                    }
-                    else if (eventArgs.Item is Episode)
-                    {
-                        itemYTId = Utils.GetVideoNameFromPath(eventArgs.Item.Path);
-                    }
-                    else
-                    {
-                        return;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "Error while processing item path: {ItemPath}", eventArgs.Item.Path ?? "null");
-                    return;
-                }
-
-                try
-                {
-                    var statusCode = await TubeArchivistApi.GetInstance().SetWatchedStatus(itemYTId, isPlayed).ConfigureAwait(true);
-                    if (statusCode != System.Net.HttpStatusCode.OK)
-                    {
-                        Logger.LogCritical("POST /watched returned {StatusCode} for item {ItemName} ({VideoYTId}) with watched status {IsPlayed}", statusCode, eventArgs.Item.Name, itemYTId, isPlayed);
-                    }
-
-                    if (eventArgs.Item is Episode)
-                    {
-                        var progress = _userDataManager.GetUserData(user, eventArgs.Item).PlaybackPositionTicks / TimeSpan.TicksPerSecond;
-                        var videoId = Utils.GetVideoNameFromPath(eventArgs.Item.Path);
-                        statusCode = await TubeArchivistApi.GetInstance().SetProgress(videoId, progress).ConfigureAwait(true);
-                        if (statusCode != System.Net.HttpStatusCode.OK)
+                        if (eventArgs.Item is Series)
                         {
-                            Logger.LogCritical("{Message}", $"POST /video/{videoId}/progress returned {statusCode} for video {eventArgs.Item.Name} with progress {progress} seconds");
+                            itemYTId = Utils.GetChannelNameFromPath(eventArgs.Item.Path);
+                        }
+                        else if (eventArgs.Item is Episode)
+                        {
+                            itemYTId = Utils.GetVideoNameFromPath(eventArgs.Item.Path);
+                        }
+                        else
+                        {
+                            return;
                         }
                     }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogCritical("An exception occurred while calling POST /watched for item {ItemName} ({VideoYTId}) with watched status {IsPlayed}: {ExceptionMessage}", eventArgs.Item.Name, itemYTId, isPlayed, ex.Message);
-                }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(ex, "Error while processing item path: {ItemPath}", eventArgs.Item.Path ?? "null");
+                        return;
+                    }
+
+                    try
+                    {
+                        var statusCode = await TubeArchivistApi.GetInstance().SetWatchedStatus(itemYTId, isPlayed).ConfigureAwait(true);
+                        if (statusCode != System.Net.HttpStatusCode.OK)
+                        {
+                            Logger.LogCritical("POST /watched returned {StatusCode} for item {ItemName} ({VideoYTId}) with watched status {IsPlayed}", statusCode, eventArgs.Item.Name, itemYTId, isPlayed);
+                        }
+
+                        if (eventArgs.Item is Episode)
+                        {
+                            var progress = _userDataManager.GetUserData(user, eventArgs.Item).PlaybackPositionTicks / TimeSpan.TicksPerSecond;
+                            var videoId = Utils.GetVideoNameFromPath(eventArgs.Item.Path);
+                            statusCode = await TubeArchivistApi.GetInstance().SetProgress(videoId, progress).ConfigureAwait(true);
+                            if (statusCode != System.Net.HttpStatusCode.OK)
+                            {
+                                Logger.LogCritical("{Message}", $"POST /video/{videoId}/progress returned {statusCode} for video {eventArgs.Item.Name} with progress {progress} seconds");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogCritical("An exception occurred while calling POST /watched for item {ItemName} ({VideoYTId}) with watched status {IsPlayed}: {ExceptionMessage}", eventArgs.Item.Name, itemYTId, isPlayed, ex.Message);
+                    }
                 }
                 else
                 {

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -177,6 +177,11 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
             {
                 BaseItem? season = LibraryManager.GetItemById(eventArgs.Item.ParentId);
                 BaseItem? channel = LibraryManager.GetItemById(season!.ParentId);
+                var topParent = eventArgs.Item.GetTopParent();
+
+                if ((topParent?.Name ?? string.Empty) == (Instance?.Configuration.CollectionTitle ?? string.Empty) && topParent?.Name is not null)
+                {
+                BaseItem? channel = LibraryManager.GetItemById(eventArgs.Item.ParentId);
                 BaseItem? collection = LibraryManager.GetItemById(channel!.ParentId);
                 if (collection?.Name.ToLower(CultureInfo.CurrentCulture) == Instance?.Configuration.CollectionTitle.ToLower(CultureInfo.CurrentCulture) && eventArgs.PlaybackPositionTicks != null)
                 {
@@ -188,6 +193,11 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
                         Logger.LogCritical("{Message}", $"POST /video/{videoId}/progress returned {statusCode} for video {eventArgs.Item.Name} with progress {progress} seconds");
                     }
                 }
+                }
+                else
+                {
+                    Logger.LogDebug("Parent name ({ParentName}) is not collection title({CollectionTitle})", topParent?.Name ?? string.Empty, Instance?.Configuration.CollectionTitle);
+                }
             }
         }
 
@@ -196,6 +206,10 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
             var user = _userManager.GetUserById(eventArgs.UserId);
             if (Configuration.JFTASync && user != null && Configuration.GetJFUsernamesToArray().Contains(user!.Username))
             {
+                var topParent = eventArgs.Item.GetTopParent();
+
+                if ((topParent?.Name ?? string.Empty) == (Instance?.Configuration.CollectionTitle ?? string.Empty) && topParent?.Name is not null)
+                {
                 var isPlayed = eventArgs.Item.IsPlayed(user);
                 Logger.LogDebug("User {UserId} changed watched status to {Status} for the item {ItemName}", eventArgs.UserId, isPlayed, eventArgs.Item.Name);
                 string itemYTId;
@@ -242,6 +256,11 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
                 catch (Exception ex)
                 {
                     Logger.LogCritical("An exception occurred while calling POST /watched for item {ItemName} ({VideoYTId}) with watched status {IsPlayed}: {ExceptionMessage}", eventArgs.Item.Name, itemYTId, isPlayed, ex.Message);
+                }
+                }
+                else
+                {
+                    Logger.LogDebug("Parent name ({ParentName}) is not collection title({CollectionTitle})", topParent?.Name ?? string.Empty, Instance?.Configuration.CollectionTitle);
                 }
             }
         }

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -175,13 +175,12 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
         {
             if (Instance!.Configuration.JFTASync && eventArgs.Users.Any(u => Instance!.Configuration.JFUsernameFrom.Equals(u.Username, StringComparison.Ordinal)))
             {
-                BaseItem? season = LibraryManager.GetItemById(eventArgs.Item.ParentId);
-                BaseItem? channel = LibraryManager.GetItemById(season!.ParentId);
                 var topParent = eventArgs.Item.GetTopParent();
 
                 if ((topParent?.Name ?? string.Empty) == (Instance?.Configuration.CollectionTitle ?? string.Empty) && topParent?.Name is not null)
                 {
-                BaseItem? channel = LibraryManager.GetItemById(eventArgs.Item.ParentId);
+                BaseItem? season = LibraryManager.GetItemById(eventArgs.Item.ParentId);
+                BaseItem? channel = LibraryManager.GetItemById(season!.ParentId);
                 BaseItem? collection = LibraryManager.GetItemById(channel!.ParentId);
                 if (collection?.Name.ToLower(CultureInfo.CurrentCulture) == Instance?.Configuration.CollectionTitle.ToLower(CultureInfo.CurrentCulture) && eventArgs.PlaybackPositionTicks != null)
                 {

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Providers/EpisodeMetadataProvider.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Providers/EpisodeMetadataProvider.cs
@@ -67,8 +67,10 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Providers
                 });
                 result.HasMetadata = true;
                 result.Item = video.ToEpisode();
+                result.Item.Path = info.Path;
                 result.Provider = Name;
                 result.People = peopleInfo;
+                _logger.LogInformation("{Message}", "Result of video to episode: \n" + JsonConvert.SerializeObject(result));
             }
 
             return result;

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Providers/EpisodeMetadataProvider.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Providers/EpisodeMetadataProvider.cs
@@ -70,7 +70,6 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Providers
                 result.Item.Path = info.Path;
                 result.Provider = Name;
                 result.People = peopleInfo;
-                _logger.LogInformation("{Message}", "Result of video to episode: \n" + JsonConvert.SerializeObject(result));
             }
 
             return result;

--- a/Jellyfin.Plugin.TubeArchivistMetadata/Tasks/JFToTubeArchivistProgressSyncTask.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Tasks/JFToTubeArchivistProgressSyncTask.cs
@@ -151,7 +151,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Tasks
                             foreach (Episode video in videos)
                             {
                                 var videoYTId = Utils.GetVideoNameFromPath(video.Path);
-                                _logger.LogInformation("{VideoYtId}", videoYTId);
+                                _logger.LogDebug("{VideoYtId}", videoYTId);
                                 HttpStatusCode statusCode;
 
                                 if (!isChannelCheckedForWatched && channel.IsPlayed(user))
@@ -179,7 +179,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.Tasks
                                         _logger.LogCritical("{Message}", $"POST /watched returned {statusCode} for video {video.Name} ({videoYTId}) with wacthed status {isVideoPlayed}");
                                     }
 
-                                    _logger.LogInformation("{Message}", isVideoPlayed);
+                                    _logger.LogDebug("{Message}", isVideoPlayed);
                                     if (!isVideoPlayed)
                                     {
                                         var playbackProgress = _userDataManager.GetUserData(user, video).PlaybackPositionTicks / TimeSpan.TicksPerSecond;

--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/TubeArchivistApi.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/TubeArchivistApi.cs
@@ -82,6 +82,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
             if (response.IsSuccessStatusCode)
             {
                 string rawData = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+                _logger.LogInformation("{Message}", url + ": " + rawData);
                 channel = JsonConvert.DeserializeObject<Channel>(rawData);
             }
 

--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/TubeArchivistApi.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/TubeArchivistApi.cs
@@ -82,7 +82,6 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
             if (response.IsSuccessStatusCode)
             {
                 string rawData = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-                _logger.LogInformation("{Message}", url + ": " + rawData);
                 channel = JsonConvert.DeserializeObject<Channel>(rawData);
             }
 

--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Video/Video.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Video/Video.cs
@@ -125,7 +125,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
             {
                 Name = Title,
                 Overview = Utils.FormatDescription(Description),
-                // SeasonName = Published.Year.ToString(CultureInfo.CurrentCulture),
+                SeasonName = Published.Year.ToString(CultureInfo.CurrentCulture),
                 ParentIndexNumber = Published.Year,
                 IndexNumber = (Published.Year * 10000) + (Published.Month * 100) + Published.Day,
                 SeriesName = Channel.Name,

--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Video/Video.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Video/Video.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.TubeArchivistMetadata.Utilities;
 using MediaBrowser.Controller.Entities;

--- a/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Video/Video.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/TubeArchivist/Video/Video.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.TubeArchivistMetadata.Utilities;
 using MediaBrowser.Controller.Entities;
@@ -124,8 +125,9 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata.TubeArchivist
             {
                 Name = Title,
                 Overview = Utils.FormatDescription(Description),
-                SeasonName = Published.Year.ToString(CultureInfo.CurrentCulture),
+                // SeasonName = Published.Year.ToString(CultureInfo.CurrentCulture),
                 ParentIndexNumber = Published.Year,
+                IndexNumber = (Published.Year * 10000) + (Published.Month * 100) + Published.Day,
                 SeriesName = Channel.Name,
                 ProductionYear = Published.Year,
                 PremiereDate = Published,


### PR DESCRIPTION
Changes: 
- Playback Progress and Watched Status Handling:
  * Updated `OnPlaybackProgress` method and added check to `OnWatchedStatusChange` method to use `GetTopParent()` for determining the top-level parent item, which should avoid a potential null pointer type exception if in a weird state. `eventArgs.Item.GetTopParent()` should be the collection title and avoids stepping up the hierarchy. If we want to still step up the hierarchy to get the channel and season then we can still do that after checking the top parent. [[1]](diffhunk://#diff-4c1026650550da3ffd1fe5f3f0df3f69edaac2b6a314c2b9b379b0fe3d20a768L176-R182) [[2]](diffhunk://#diff-4c1026650550da3ffd1fe5f3f0df3f69edaac2b6a314c2b9b379b0fe3d20a768L192-R203)

- Metadata Enhancements:
  * Added `Path` assignment to `result.Item` in `GetMetadata`.
  * `IndexNumber` in `ToEpisode` uses YYYYMMDD as a number to sort nicely.

- Logging:
  * Changed logging levels from `LogInformation` to `LogDebug` in `JFToTubeArchivistProgressSyncTask` to prevent so much being printed unnecessarily since it does slow down startup if the sync task is set to run "on application startup" [[1]](diffhunk://#diff-6e12253dcd80b45f0c2996e0a8b1204bdfa9e24ab3a273f3c8287e7e8bf74965L154-R154) [[2]](diffhunk://#diff-6e12253dcd80b45f0c2996e0a8b1204bdfa9e24ab3a273f3c8287e7e8bf74965L182-R182)