### PR TITLE
Update Plugin.cs - Guid empty

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -175,7 +175,7 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
         {
             if (eventArgs == null || eventArgs.ItemId == Guid.Empty)
             {
-                Logger.LogWarning("PlaybackProgress called with null or empty Guid.");
+                Logger.LogDebug("Skipping progress synchronization: PlaybackProgress event triggered with null or empty Guid.");
                 return;
             }
             if (Instance!.Configuration.JFTASync && eventArgs.Users.Any(u => Instance!.Configuration.JFUsernameFrom.Equals(u.Username, StringComparison.Ordinal)))


### PR DESCRIPTION
Getting this error:
[2025-06-16 00:41:58.499 +00:00] [FTL] Unhandled Exception   System.ArgumentException: Guid can't be empty (Parameter 'id')   at Jellyfin.Plugin.TubeArchivistMetadata.Plugin.OnPlaybackProgress(...)

And right after playback fails
[2025-06-16 00:42:23.345 +00:00] [INF] Playback stopped reported by app "Jellyfin Roku" "3.0.5" playing "Video". Stopped at "973000" ms