### PR TITLE
Fix: Prevent crash when playing non-TubeArchivist media (Issue #60)

### DIFF
--- a/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.TubeArchivistMetadata/Plugin.cs
@@ -161,6 +161,12 @@ namespace Jellyfin.Plugin.TubeArchivistMetadata
 
             if (Instance!.Configuration.JFTASync && eventArgs.Users.Any(u => Instance!.Configuration.JFUsernameFrom.Equals(u.Username, StringComparison.Ordinal)))
             {
+                // Only process Episodes (YouTube videos), not Movies or other media types
+                if (eventArgs.Item is not Episode)
+                {
+                    return;
+                }
+
                 BaseItem? season = LibraryManager.GetItemById(eventArgs.Item.ParentId);
                 BaseItem? channel = LibraryManager.GetItemById(season!.ParentId);
                 BaseItem? collection = LibraryManager.GetItemById(channel!.ParentId);


### PR DESCRIPTION
## Problem
The plugin crashes with `System.ArgumentException: Guid can't be empty (Parameter 'id')` when users play movies or other non-TubeArchivist content.

## Root Cause
The `OnPlaybackProgress` method in `Plugin.cs` (line 178) attempts to traverse the TV show hierarchy (Episode → Season → Series → Collection) for ALL media playback events, including movies. Since movies don't follow this hierarchy structure, calling `GetItemById()` on a movie's parent can result in empty GUIDs, causing an exception.

## Changes Made
Added a type check to immediately return if the item is not an Episode, before attempting any hierarchy traversal:
```csharp
// Only process Episodes (YouTube videos), not Movies or other media types
if (eventArgs.Item is not Episode)
{
    return;
}
```

This ensures the plugin only processes TubeArchivist content (YouTube videos stored as TV Episodes) and safely ignores movies, music, and other media types.

## Testing
Tested in Docker container with Jellyfin 10.10.7:
- Movie playback - no crashes, properly ignored by plugin
- TubeArchivist video playback - still syncs progress correctly  
- Progress sync to TubeArchivist API - verified working

## Before Fix
```
[FTL] Main: Unhandled Exception
System.ArgumentException: Guid can't be empty (Parameter 'id')
   at Emby.Server.Implementations.Library.LibraryManager.GetItemById(Guid id)
   at Jellyfin.Plugin.TubeArchivistMetadata.Plugin.OnPlaybackProgress(...)
```

## After Fix
```
[INF] User started playing "10 Things I Hate About You"
[INF] Playback stopped... Stopped at 83955 ms
```
(No errors - movie playback ignored as expected)

Fixes #60